### PR TITLE
Fix test for non-existent tag filter

### DIFF
--- a/tests/Functional/VideoGame/FilterTest.php
+++ b/tests/Functional/VideoGame/FilterTest.php
@@ -84,7 +84,13 @@ final class FilterTest extends FunctionalTestCase
     public function testShouldFilterWithNonExistentTag() {
 
         // Load page with parameters and an invalid tag
-        $this->client->request('GET', "/", ['page' => 1, 'limit' => 999, 'filter[tags]' => 999]);
+        $this->client->request('GET', "/", [
+            'page' => 1,
+            'limit' => 999,
+            'filter' => [
+                'tags' => [999]
+            ]
+        ]);
         self::assertResponseIsSuccessful();
 
         // Assert all games are displayed


### PR DESCRIPTION
## What I did
Fixed syntax error in `testShouldFilterWithNonExistentTag`:
- Changed `'filter[tags]' => 999` to `'filter' => ['tags' => [999]]`
- Now correctly tests filtering with a non-existent tag ID

Test now passes ✅